### PR TITLE
Small Fix for Windows Users

### DIFF
--- a/src/rx-slow-hash.c
+++ b/src/rx-slow-hash.c
@@ -33,8 +33,14 @@
 #include <string.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <unistd.h>
 #include <limits.h>
+
+/* Unistd.h is only avalible on UNIX Systems, Unless we were using a WSL*/
+#ifndef _WIN32
+  #include <unistd.h>
+#else
+  #include <windows.h>
+#endif
 
 #include "randomx.h"
 #include "c_threads.h"


### PR DESCRIPTION
I found this  repository about a year ago when I was playing around with some of it's parts and then I decided to come back since I am working on a new Python RandomX library in Cython. When looking for examples of programs that can mine Monero I ended up re-finding this repository and the `#include <unistd.h>` statement bothered me quite a bit since I'm a windows user and I don't have `unistd.h` file, so I wanted to try to attempt to fix this problem for windows users who were attempting to install this repository and aren't using a Linux Subsystem to compile it. Let me know if this doesn't work or fails to compile so that I can find other ways to fix these installation issues.
